### PR TITLE
Update to 1.0

### DIFF
--- a/app.drey.Elastic.json
+++ b/app.drey.Elastic.json
@@ -1,7 +1,7 @@
 {
     "app-id": "app.drey.Elastic",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "app.drey.Elastic",
     "finish-args": [
@@ -24,18 +24,6 @@
     ],
     "modules": [
         {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": ["*"],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                    "tag": "v0.16.0"
-                }
-            ]
-        },
-        {
             "name": "template-glib",
             "buildsystem": "meson",
             "config-opts": [
@@ -46,8 +34,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/template-glib.git",
-                    "tag": "3.36.3",
-                    "commit": "a13d1ada1ac01794a06cff99989bedbb4715e6c8",
+                    "tag": "3.38.0",
+                    "commit": "3a80bca76cb4d993f3af9c6dd43a5a1553f23207",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "template-glib",
@@ -63,8 +51,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/World/elastic.git",
-                    "tag": "0.1.9",
-                    "commit": "cfe7e22ca95e339d753bf926a22ec62a421e9376",
+                    "tag": "1.0",
+                    "commit": "cf1f99af9b6f30a05380b0a23f91d2a3bf632907",
                     "x-checker-data": {
                         "type": "git",
                         "name": "^([\\d.])$"


### PR DESCRIPTION
- Bump SDK to 49
- Update template-glib to 3.38.0
- Remove blueprint-compiler since it's in the SDK now